### PR TITLE
Read credentials from environment

### DIFF
--- a/amazon/paapi.py
+++ b/amazon/paapi.py
@@ -19,7 +19,7 @@ from paapi5_python_sdk.get_browse_nodes_request import GetBrowseNodesRequest
 
 
 
-import time, json, pickle, pprint
+import time, json, pickle, pprint, os
 from urllib.parse import quote as urllib_quote
 from .entities import AmazonProduct, AmazonBrowseNode
 from .constant import *
@@ -92,7 +92,7 @@ class AmazonAPI:
     
     
     """
-    def __init__(self, access_key, secret_key, partner_tag, country='US', throttling=0.9, CacheReader=None, CacheWriter=None):
+    def __init__(self, access_key=None, secret_key=None, partner_tag=None, country='US', throttling=0.9, CacheReader=None, CacheWriter=None):
         """
             init AmazonApi. It is necessary to specify *access_key, secret_key, partner_tag, country* parameters
             By default the throttling parameter is set to 0.9. Increse or descrease this number to manage the time among different calls
@@ -114,9 +114,13 @@ class AmazonAPI:
                     function to write results into the cache 
 
         """
-        self.access_key = access_key
-        self.secret_key = secret_key
-        self.partner_tag = partner_tag
+        self.access_key = access_key or os.environ.get('AWS_ACCESS_KEY_ID')
+        self.secret_key = secret_key or os.environ.get('AWS_SECRET_ACCESS_KEY')
+        self.partner_tag = partner_tag or os.environ.get('AWS_ASSOCIATE_TAG')
+
+        if not all([self.access_key, self.secret_key, self.partner_tag]):
+            raise AmazonException('Missing Credentials (AccessKey, SecretKey or AssociateTag). Please specify credentials.')
+
         self.throttling = throttling
         self.country = country
         self.host = 'webservices.amazon.' + DOMAINS[country]


### PR DESCRIPTION
Effectively a copy of Bottlenose PR #24 (lionheart/bottlenose#24)

`access_key`, `secret_key` and `associate_tag` can be passed or read from the environment. Added early check to ensure credentials are set.